### PR TITLE
Removed Beta warning message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-> **⚠️ Note:** To use this GitHub Action, you must have access to GitHub Actions. GitHub Actions are currently only available in public beta (you must apply for access).
-
 This action is a part of [GitHub Actions Library](https://github.com/rtCamp/github-actions-library/) created by [rtCamp](https://github.com/rtCamp/).
 
 # Slack Notify - GitHub Action


### PR DESCRIPTION
As of [Universe 2019](https://github.blog/2019-11-13-universe-day-one/#github-actions), _actions_ are now publicly available.