### PR TITLE
Run action directly from docker image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'This action will send a notification to Slack'
 author: 'rtCamp'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://rtcamp/action-slack-notify:master'
 branding:
   icon: 'bell'
   color: 'yellow'


### PR DESCRIPTION
Closes: #16 

Adding docker image that will stay in sync with change in `master` branch for now.
Will update and maintain docker images with all the tags and switch to using GitHub `tag` as the docker image tag as well.