### PR TITLE
Add rsync tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN apk update \
 	jq \
 	ca-certificates \
 	python \
-	py2-pip && \
+	py2-pip \
+	rsync && \
 	pip install shyaml && \
 	rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
File overrides are copied out of `$GITHUB_WORKSPACE/.github/slack` in entrypoint using rsync, but rsync was never installed in the container