### PR TITLE
Allow custom footer messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ SLACK_ICON_EMOJI  | -                                                     | User
 SLACK_COLOR       | `good` (green)                                        | You can pass an RGB value like `#efefef` which would change color on left side vertical line of Slack message.
 SLACK_MESSAGE     | Generated from git commit message.                    | The main Slack message in attachment. It is advised not to override this.
 SLACK_TITLE       | Message                                               | Title to use before main Slack message.
+SLACK_FOOTER      | Powered By rtCamp's GitHub Actions Library            | Slack message footer.
 MSG_MINIMAL       | -                                                     | If set to true, removes: `Ref`, `Event` and `Actions URL` from the message.
 
 

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ const (
 	EnvSlackMessage   = "SLACK_MESSAGE"
 	EnvSlackColor     = "SLACK_COLOR"
 	EnvSlackUserName  = "SLACK_USERNAME"
+	EnvSlackFooter    = "SLACK_FOOTER"
 	EnvGithubActor    = "GITHUB_ACTOR"
 	EnvSiteName       = "SITE_NAME"
 	EnvHostName       = "HOST_NAME"
@@ -129,7 +130,7 @@ func main() {
 				AuthorName: envOr(EnvGithubActor, ""),
 				AuthorLink: "http://github.com/" + os.Getenv(EnvGithubActor),
 				AuthorIcon: "http://github.com/" + os.Getenv(EnvGithubActor) + ".png?size=32",
-				Footer: "<https://github.com/rtCamp/github-actions-library|Powered By rtCamp's GitHub Actions Library>",
+				Footer: envOr(EnvSlackFooter, "<https://github.com/rtCamp/github-actions-library|Powered By rtCamp's GitHub Actions Library>"),
 				Fields: fields,
 			},
 		},


### PR DESCRIPTION
Allowing to control the footer text through the `SLACK_FOOTER` environment variable can be useful to specify custom hints along with the message.

If the variable is unset, the default _"Powered By rtCamp's GitHub Actions Library"_ text will be used.