### PR TITLE
Fix support for SLACK_ICON_EMOJI

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -53,4 +53,8 @@ if [[ -z "$SLACK_MESSAGE" ]]; then
 	export SLACK_MESSAGE="$COMMIT_MESSAGE"
 fi
 
+if [[ -n "$SLACK_ICON_EMOJI" ]]; then
+	export SLACK_ICON_EMOJI=${SLACK_ICON_EMOJI}
+fi
+
 slack-notify "$@"

--- a/main.sh
+++ b/main.sh
@@ -51,6 +51,8 @@ fi
 
 if [[ -z "$SLACK_MESSAGE" ]]; then
 	export SLACK_MESSAGE="$COMMIT_MESSAGE"
+else
+	export SLACK_MESSAGE=${SLACK_MESSAGE}
 fi
 
 if [[ -n "$SLACK_ICON_EMOJI" ]]; then


### PR DESCRIPTION
It seems as though `$SLACK_ICON_EMOJI` needs to be explicitly `export`ed in order for `slack-notify` to pick it up.  I dunno if y'all want to put some more guards around it or provide a default or not, but this can serve as a starting point.

Thanks for the action BTW it's been super helpful!