### PR TITLE
Surround job status with backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ SLACK_USERNAME    | `rtBot`                                               | Cust
 SLACK_MSG_AUTHOR  | `$GITHUB_ACTOR` (The person who triggered action).    | GitHub username of the person who has triggered the action. In case you want to modify it, please specify corrent GitHub username.
 SLACK_ICON        | ![rtBot Avatar](https://github.com/rtBot.png?size=32) | User/Bot icon shown with Slack message. It uses the URL supplied to this env variable to display the icon in slack message.
 SLACK_ICON_EMOJI  | -                                                     | User/Bot icon shown with Slack message, in case you do not wish to add a URL for slack icon as above, you can set slack emoji in this env variable. Example value: `:bell:` or any other valid slack emoji.
-SLACK_COLOR       | `good` (green)                                        | You can pass ${{job.status}} for automatic coloring or an RGB value like `#efefef` which would change color on left side vertical line of Slack message.
+SLACK_COLOR       | `good` (green)                                        | You can pass `${{ job.status }}` for automatic coloring or an RGB value like `#efefef` which would change color on left side vertical line of Slack message.
 SLACK_MESSAGE     | Generated from git commit message.                    | The main Slack message in attachment. It is advised not to override this.
 SLACK_TITLE       | Message                                               | Title to use before main Slack message.
 SLACK_FOOTER      | Powered By rtCamp's GitHub Actions Library            | Slack message footer.


### PR DESCRIPTION
Fix a small typo around job status variable in README. Now it looks like better in between backticks since it is a code piece.