### PR TITLE
Add SLACK_ICON_EMOJI to main.sh for use in Docker

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -2,6 +2,7 @@
 
 export GITHUB_BRANCH=${GITHUB_REF##*heads/}
 export SLACK_ICON=${SLACK_ICON:-"https://avatars0.githubusercontent.com/u/43742164"}
+export SLACK_ICON_EMOJI=${SLACK_ICON_EMOJI}
 export SLACK_USERNAME=${SLACK_USERNAME:-"rtBot"}
 export CI_SCRIPT_OPTIONS="ci_script_options"
 export SLACK_TITLE=${SLACK_TITLE:-"Message"}


### PR DESCRIPTION
- [x] add SLACK_ICON_EMOJI environment variable to main.sh to use during docker container creation and use in Github Actions

I am not currently able to get SLACK_ICON_EMOJI to work and I believe this is the cause.  I'm setting it in my github action step as an ENV but it is not getting to the container.