### PR TITLE
Remove Slack Icon and Slack Icon Emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ Variable          | Default                                               | Purp
 SLACK_CHANNEL     | Set during Slack webhook creation                     | Specify Slack channel in which message needs to be sent
 SLACK_USERNAME    | `rtBot`                                               | Custom Slack Username sending the message. Does not need to be a "real" username.
 SLACK_MSG_AUTHOR  | `$GITHUB_ACTOR` (The person who triggered action).    | GitHub username of the person who has triggered the action. In case you want to modify it, please specify corrent GitHub username.
-SLACK_ICON        | ![rtBot Avatar](https://github.com/rtBot.png?size=32) | User/Bot icon shown with Slack message. It uses the URL supplied to this env variable to display the icon in slack message.
-SLACK_ICON_EMOJI  | -                                                     | User/Bot icon shown with Slack message, in case you do not wish to add a URL for slack icon as above, you can set slack emoji in this env variable. Example value: `:bell:` or any other valid slack emoji.
 SLACK_COLOR       | `good` (green)                                        | You can pass `${{ job.status }}` for automatic coloring or an RGB value like `#efefef` which would change color on left side vertical line of Slack message.
 SLACK_MESSAGE     | Generated from git commit message.                    | The main Slack message in attachment. It is advised not to override this.
 SLACK_TITLE       | Message                                               | Title to use before main Slack message.
@@ -62,7 +60,6 @@ You can see the action block with all variables as below:
       env:
         SLACK_CHANNEL: general
         SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'
-        SLACK_ICON: https://github.com/rtCamp.png?size=48
         SLACK_MESSAGE: 'Post Content :rocket:'
         SLACK_TITLE: Post Title
         SLACK_USERNAME: rtCamp

--- a/main.go
+++ b/main.go
@@ -10,26 +10,22 @@ import (
 )
 
 const (
-	EnvSlackWebhook   = "SLACK_WEBHOOK"
-	EnvSlackIcon      = "SLACK_ICON"
-	EnvSlackIconEmoji = "SLACK_ICON_EMOJI"
-	EnvSlackChannel   = "SLACK_CHANNEL"
-	EnvSlackTitle     = "SLACK_TITLE"
-	EnvSlackMessage   = "SLACK_MESSAGE"
-	EnvSlackColor     = "SLACK_COLOR"
-	EnvSlackUserName  = "SLACK_USERNAME"
-	EnvSlackFooter    = "SLACK_FOOTER"
-	EnvGithubActor    = "GITHUB_ACTOR"
-	EnvSiteName       = "SITE_NAME"
-	EnvHostName       = "HOST_NAME"
-	EnvMinimal        = "MSG_MINIMAL"
+	EnvSlackWebhook  = "SLACK_WEBHOOK"
+	EnvSlackChannel  = "SLACK_CHANNEL"
+	EnvSlackTitle    = "SLACK_TITLE"
+	EnvSlackMessage  = "SLACK_MESSAGE"
+	EnvSlackColor    = "SLACK_COLOR"
+	EnvSlackUserName = "SLACK_USERNAME"
+	EnvSlackFooter   = "SLACK_FOOTER"
+	EnvGithubActor   = "GITHUB_ACTOR"
+	EnvSiteName      = "SITE_NAME"
+	EnvHostName      = "HOST_NAME"
+	EnvMinimal       = "MSG_MINIMAL"
 )
 
 type Webhook struct {
 	Text        string       `json:"text,omitempty"`
 	UserName    string       `json:"username,omitempty"`
-	IconURL     string       `json:"icon_url,omitempty"`
-	IconEmoji   string       `json:"icon_emoji,omitempty"`
 	Channel     string       `json:"channel,omitempty"`
 	UnfurlLinks bool         `json:"unfurl_links"`
 	Attachments []Attachment `json:"attachments,omitempty"`
@@ -191,10 +187,8 @@ func main() {
 	}
 
 	msg := Webhook{
-		UserName:  os.Getenv(EnvSlackUserName),
-		IconURL:   os.Getenv(EnvSlackIcon),
-		IconEmoji: os.Getenv(EnvSlackIconEmoji),
-		Channel:   os.Getenv(EnvSlackChannel),
+		UserName: os.Getenv(EnvSlackUserName),
+		Channel:  os.Getenv(EnvSlackChannel),
 		Attachments: []Attachment{
 			{
 				Fallback:   envOr(EnvSlackMessage, "GITHUB_ACTION="+os.Getenv("GITHUB_ACTION")+" \n GITHUB_ACTOR="+os.Getenv("GITHUB_ACTOR")+" \n GITHUB_EVENT_NAME="+os.Getenv("GITHUB_EVENT_NAME")+" \n GITHUB_REF="+os.Getenv("GITHUB_REF")+" \n GITHUB_REPOSITORY="+os.Getenv("GITHUB_REPOSITORY")+" \n GITHUB_WORKFLOW="+os.Getenv("GITHUB_WORKFLOW")),

--- a/main.sh
+++ b/main.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 export GITHUB_BRANCH=${GITHUB_REF##*heads/}
-export SLACK_ICON=${SLACK_ICON:-"https://avatars0.githubusercontent.com/u/43742164"}
 export SLACK_USERNAME=${SLACK_USERNAME:-"rtBot"}
 export CI_SCRIPT_OPTIONS="ci_script_options"
 export SLACK_TITLE=${SLACK_TITLE:-"Message"}


### PR DESCRIPTION
Due to changes implemented by Slack, "You can't override...icon when you're using Incoming Webhooks to post messages" from https://api.slack.com/messaging/webhooks#advanced_message_formatting

- [x] update README
- [x] remove attributes from Webhook struct
- [x] remove constants representing environment variable keys and their usages
- [x] remote SLACK_ICON usage from main.sh, used by Dockerfile and entrypoint.sh

Closes #90 