### PR TITLE
chore: Update the description of SLACK_COLOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can see the action block with all variables as below:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_CHANNEL: general
-        SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'
+        SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
         SLACK_ICON: https://github.com/rtCamp.png?size=48
         SLACK_MESSAGE: 'Post Content :rocket:'
         SLACK_TITLE: Post Title


### PR DESCRIPTION
Message attachments `color` field supports `good`,`warning`,`danger` and hex color code.
ref: https://api.slack.com/reference/messaging/attachments#fields