### PR TITLE
lowercase EnvSlackColor

### DIFF
--- a/main.go
+++ b/main.go
@@ -181,7 +181,7 @@ func main() {
 	}
 
 	color := ""
-	switch os.Getenv(EnvSlackColor) {
+	switch strings.ToLower(os.Getenv(EnvSlackColor)){
 	case "success":
 		color = "good"
 	case "cancelled":


### PR DESCRIPTION
Github Actions sends the ${{ github.action_status }} variable as "Success" which breaks the switch case.
I've added a strings.ToLower() to the EnvSlackColor.