### PR TITLE
upgrade pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apk update \
 	jq \
 	ca-certificates \
 	python \
+	pip install --upgrade pip \
 	py2-pip \
 	rsync && \
 	pip install shyaml && \


### PR DESCRIPTION
```
Step 15/20 : RUN apk update 	&& apk upgrade 	&& apk add 	bash 	jq 	ca-certificates 	python 	py2-pip && 	pip install shyaml && 	rm -rf /var/cache/apk/*
   ---> Running in 6b35a046e6ad
  fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
  fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
  v3.8.5-67-gf94de196ca [http://dl-cdn.alpinelinux.org/alpine/v3.8/main]
  v3.8.5-66-gccbd6a8ae7 [http://dl-cdn.alpinelinux.org/alpine/v3.8/community]
  OK: 9571 distinct packages available
  Upgrading critical system libraries and apk-tools:
  (1/1) Upgrading apk-tools (2.10.1-r0 -> 2.10.6-r0)
  Executing busybox-1.28.4-r2.trigger
  Continuing the upgrade transaction with new apk-tools:
  (1/7) Upgrading musl (1.1.19-r10 -> 1.1.19-r11)
  (2/7) Upgrading busybox (1.28.4-r2 -> 1.28.4-r3)
  Executing busybox-1.28.4-r3.post-upgrade
  (3/7) Upgrading libressl2.7-libcrypto (2.7.4-r0 -> 2.7.5-r0)
  (4/7) Upgrading libressl2.7-libssl (2.7.4-r0 -> 2.7.5-r0)
  (5/7) Upgrading libressl2.7-libtls (2.7.4-r0 -> 2.7.5-r0)
  (6/7) Upgrading ssl_client (1.28.4-r2 -> 1.28.4-r3)
  (7/7) Upgrading musl-utils (1.1.19-r10 -> 1.1.19-r11)
  Executing busybox-1.28.4-r3.trigger
  OK: 4 MiB in 13 packages
  (1/16) Installing ncurses-terminfo-base (6.1_p20180818-r1)
  (2/16) Installing ncurses-terminfo (6.1_p20180818-r1)
  (3/16) Installing ncurses-libs (6.1_p20180818-r1)
  (4/16) Installing readline (7.0.003-r0)
  (5/16) Installing bash (4.4.19-r1)
  Executing bash-4.4.19-r1.post-install
  (6/16) Installing ca-certificates (20191127-r2)
  (7/16) Installing oniguruma (6.9.4-r0)
  (8/16) Installing jq (1.6_rc1-r1)
  (9/16) Installing libbz2 (1.0.6-r7)
  (10/16) Installing expat (2.2.8-r0)
  (11/16) Installing libffi (3.2.1-r4)
  (12/16) Installing gdbm (1.13-r1)
  (13/16) Installing sqlite-libs (3.25.3-r4)
  (14/16) Installing python2 (2.7.15-r3)
  (15/16) Installing py-setuptools (39.1.0-r0)
  (16/16) Installing py2-pip (10.0.1-r0)
  Executing busybox-1.28.4-r3.trigger
  Executing ca-certificates-20191127-r2.trigger
  OK: 66 MiB in 29 packages
  Collecting shyaml
    Downloading https://files.pythonhosted.org/packages/2a/5c/139cda90758d6bc18a16876a2c291[264](https://github.com/cardoc/platform-api/actions/runs/5581958749/jobs/10200700461#step:2:264)cf06fd736ca54606862a43931877/shyaml-0.6.2-py2.py3-none-any.whl
  Collecting pyyaml (from shyaml)
    Downloading https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz (175kB)
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
      Complete output from command python setup.py egg_info:
      running egg_info
      creating pip-egg-info/PyYAML.egg-info
      writing pip-egg-info/PyYAML.egg-info/PKG-INFO
      writing top-level names to pip-egg-info/PyYAML.egg-info/top_level.txt
      writing dependency_links to pip-egg-info/PyYAML.egg-info/dependency_links.txt
      writing manifest file 'pip-egg-info/PyYAML.egg-info/SOURCES.txt'
      Traceback (most recent call last):
        File "<string>", line 1, in <module>
        File "/tmp/pip-install-87mr6s/pyyaml/setup.py", line 295, in <module>
          python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
        File "/tmp/pip-build-env-qRcGwa/lib/python2.7/site-packages/setuptools/__init__.py", line 162, in setup
          return distutils.core.setup(**attrs)
        File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
          dist.run_commands()
        File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
          self.run_command(cmd)
        File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-qRcGwa/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 296, in run
          self.find_sources()
        File "/tmp/pip-build-env-qRcGwa/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 303, in find_sources
          mm.run()
        File "/tmp/pip-build-env-qRcGwa/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 534, in run
          self.add_defaults()
        File "/tmp/pip-build-env-qRcGwa/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 570, in add_defaults
          sdist.add_defaults(self)
        File "/tmp/pip-build-env-qRcGwa/lib/python2.7/site-packages/setuptools/command/py36compat.py", line 36, in add_defaults
          self._add_defaults_ext()
        File "/tmp/pip-build-env-qRcGwa/lib/python2.7/site-packages/setuptools/command/py36compat.py", line 120, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
        File "/tmp/pip-install-87mr6s/pyyaml/setup.py", line 201, in get_source_files
          self.cython_sources(ext.sources, ext)
        File "/usr/lib/python2.7/distutils/cmd.py", line 105, in __getattr__
          raise AttributeError, attr
      AttributeError: cython_sources
      
      ----------------------------------------
  Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-87mr6s/pyyaml/
  You are using pip version 10.0.1, however version 20.3.4 is available.
  You should consider upgrading via the 'pip install --upgrade pip' command.
  The command '/bin/sh -c apk update 	&& apk upgrade 	&& apk add 	bash 	jq 	ca-certificates 	python 	py2-pip && 	pip install shyaml && 	rm -rf /var/cache/apk/*' returned a non-zero code: 1
```