### PR TITLE
Fix `invalid reference format: repository name must be lowercase` error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,11 +17,11 @@ runs:
           SLACK_MESSAGE: "${{ steps.slackify.outputs.text }}"
           GITHUB_RUN: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
           ENABLE_ESCAPES: "true"
-        uses: "docker://ghcr.io/rtCamp/action-slack-notify:v2.2.1"
+        uses: "docker://ghcr.io/rtcamp/action-slack-notify:v2.2.1"
 
       - name: "Slack Notification (Unformatted)"
         if: env.SLACKIFY_MARKDOWN != 'true'
-        uses: "docker://ghcr.io/rtCamp/action-slack-notify:v2.2.1"
+        uses: "docker://ghcr.io/rtcamp/action-slack-notify:v2.2.1"
         env:
           GITHUB_RUN: "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
 branding:


### PR DESCRIPTION
## Issue

The https://github.com/rtCamp/action-slack-notify/commit/a7edf7ee583d3f0daf279d29bc2076f1f37d6eca change broke all workflows using this GitHub Actions with references to `master`.

It caused `invalid reference format: repository name must be lowercase` errors.

<img width="1125" alt="image" src="https://github.com/rtCamp/action-slack-notify/assets/1811616/7aa7148d-6e91-4086-9dd0-e122b443baa3">


## Change

This pull request just reverts the repository name so it doesn't have disallowed cases.