### PR TITLE
Update CI and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - mrrobot47
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - mrrobot47

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+on:
+  push:
+    tags:
+      - "v*"
+name: Release Creation
+jobs:
+  release:
+    name: Create a Draft Release on GitHub
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get Release Name
+      id: get_release_name
+      run: |
+        echo "release_name=${GITHUB_REF_NAME/v/Version }" >> $GITHUB_ENV
+    - name: Publish a Draft Release
+      uses: softprops/action-gh-release@v2
+      with:
+        body: |
+          We present you the new release of Action Slack Notify.
+
+          **Changelog:**
+        draft: true  # Creates a Draft Release
+        name: ${{ steps.get_release_name.outputs.release_name }}
+        generate_release_notes: true
+        append_body: true
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         body: |
-          We present you the new release of Action Slack Notify.
+          ## What's Changed
 
           **Changelog:**
         draft: true  # Creates a Draft Release


### PR DESCRIPTION
This PR makes the following changes:

- Adds Dependabot dependency monitoring for weekly dependency updates
- Adds an action to create a draft release whenever a new tag is pushed to the repository