### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
     name: Slack Notification
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Slack Notification
       uses: rtCamp/action-slack-notify@v2
       env:
@@ -107,7 +107,7 @@ jobs:
     name: Slack Notification
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Slack Notification
       uses: rtCamp/action-slack-notify@v2
       env:


### PR DESCRIPTION
actions/checkout@v2 is out of date, rewritten to actions/checkout@v4.

I used git grep to see if there were any other places where actions/checkout@v2 was used.

```
$  git grep -n "actions/checkout"
.github/workflows/build.yaml:16:          uses: actions/checkout@v4
README.md:30:    - uses: actions/checkout@v4
README.md:110:    - uses: actions/checkout@v4
```

Looks good.