### PR TITLE
Remove message title when MSG_MINIMAL is true Done

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,7 +138,6 @@ func main() {
 		if minimal == "true" {
 			mainFields := []Field{
 				{
-					Title: getEnv(EnvSlackTitle),
 					Value: text,
 					Short: false,
 				},


### PR DESCRIPTION
### What this PR does
When `MSG_MINIMAL` is set to `true`, the Slack message still included a title/heading derived from `SLACK_TITLE`.

This PR updates the minimal message mode to omit the field title entirely, ensuring the message is rendered without a heading, as expected.

### Why this change is needed
The current behavior contradicts the intention of `MSG_MINIMAL`, which is to send a simplified message without additional headings or metadata.

### Scope of change
- Only affects `MSG_MINIMAL=true`
- No changes to selective minimal mode (e.g. `MSG_MINIMAL=ref,event`)
- No changes to default/full message behavior

Fixes #194
